### PR TITLE
Added the ability to execute FFmpeg and FFprobe synchronously

### DIFF
--- a/android-ffmpeg/src/main/java/nl/bravobit/ffmpeg/FFbinaryInterface.java
+++ b/android-ffmpeg/src/main/java/nl/bravobit/ffmpeg/FFbinaryInterface.java
@@ -24,6 +24,23 @@ interface FFbinaryInterface {
     FFtask execute(String[] cmd, FFcommandExecuteResponseHandler ffcommandExecuteResponseHandler);
 
     /**
+     * Executes a command synchronously
+     *
+     * @param environmentVars                 Environment variables
+     * @param cmd                             command to execute
+     * @return The output of the command
+     */
+    String execute(Map<String, String> environmentVars, String[] cmd);
+
+    /**
+     * Executes a command synchronously
+     *
+     * @param cmd                             command to execute
+     * @return The output of the command
+     */
+    String execute(String[] cmd);
+
+    /**
      * Checks if FF binary is supported on this device
      *
      * @return true if FF binary is supported on this device

--- a/android-ffmpeg/src/main/java/nl/bravobit/ffmpeg/FFcommandExecuteSynchronous.java
+++ b/android-ffmpeg/src/main/java/nl/bravobit/ffmpeg/FFcommandExecuteSynchronous.java
@@ -1,0 +1,78 @@
+package nl.bravobit.ffmpeg;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+
+public class FFcommandExecuteSynchronous {
+
+    private final String[] cmd;
+    private Map<String, String> environment;
+    private final ShellCommand shellCommand;
+    private final long timeout;
+    private long startTime;
+    private Process process;
+    private String output = "";
+
+    FFcommandExecuteSynchronous(String[] cmd, Map<String, String> environment, long timeout) {
+        this.cmd = cmd;
+        this.timeout = timeout;
+        this.environment = environment;
+        this.shellCommand = new ShellCommand();
+    }
+
+    private CommandResult runCommand() {
+        startTime = System.currentTimeMillis();
+        try {
+            process = shellCommand.run(cmd, environment);
+            if (process == null) {
+                return CommandResult.getDummyFailureResponse();
+            }
+            Log.d("Running publishing updates method");
+            checkAndUpdateProcess();
+            return CommandResult.getOutputFromProcess(process);
+        } catch (TimeoutException e) {
+            Log.e("FFmpeg binary timed out", e);
+            return new CommandResult(false, e.getMessage());
+        } catch (Exception e) {
+            Log.e("Error running FFmpeg binary", e);
+        } finally {
+            Util.destroyProcess(process);
+        }
+        return CommandResult.getDummyFailureResponse();
+    }
+
+    public String execute() {
+        CommandResult commandResult = runCommand();
+        output += commandResult.output;
+        return output;
+    }
+
+    private void checkAndUpdateProcess() throws TimeoutException {
+        while (!Util.isProcessCompleted(process)) {
+
+            // checking if process is completed
+            if (Util.isProcessCompleted(process)) {
+                return;
+            }
+
+            // Handling timeout
+            if (timeout != Long.MAX_VALUE && System.currentTimeMillis() > startTime + timeout) {
+                throw new TimeoutException("FFmpeg binary timed out");
+            }
+
+            try {
+                String line;
+                BufferedReader reader = new BufferedReader(new InputStreamReader(process.getErrorStream()));
+                while ((line = reader.readLine()) != null) {
+                    output += line + "\n";
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+}

--- a/android-ffmpeg/src/main/java/nl/bravobit/ffmpeg/FFmpeg.java
+++ b/android-ffmpeg/src/main/java/nl/bravobit/ffmpeg/FFmpeg.java
@@ -139,6 +139,23 @@ public class FFmpeg implements FFbinaryInterface {
     }
 
     @Override
+    public String execute(Map<String, String> environmentVars, String[] cmd) {
+        if (cmd.length != 0) {
+            String[] ffmpegBinary = new String[]{FileUtils.getFFmpeg(context.provide()).getAbsolutePath()};
+            String[] command = concatenate(ffmpegBinary, cmd);
+            FFcommandExecuteSynchronous synchronous = new FFcommandExecuteSynchronous(command, environmentVars, timeout);
+            return synchronous.execute();
+        } else {
+            throw new IllegalArgumentException("shell command cannot be empty");
+        }
+    }
+
+    @Override
+    public String execute(String[] cmd) {
+        return execute(null, cmd);
+    }
+
+    @Override
     public boolean isCommandRunning(FFtask task) {
         return task != null && !task.isProcessCompleted();
     }

--- a/android-ffmpeg/src/main/java/nl/bravobit/ffmpeg/FFprobe.java
+++ b/android-ffmpeg/src/main/java/nl/bravobit/ffmpeg/FFprobe.java
@@ -138,6 +138,23 @@ public class FFprobe implements FFbinaryInterface {
         return execute(null, cmd, ffcommandExecuteResponseHandler);
     }
 
+    @Override
+    public String execute(Map<String, String> environmentVars, String[] cmd) {
+        if (cmd.length != 0) {
+            String[] ffprobeBinary = new String[]{FileUtils.getFFprobe(context.provide()).getAbsolutePath()};
+            String[] command = concatenate(ffprobeBinary, cmd);
+            FFcommandExecuteSynchronous synchronous = new FFcommandExecuteSynchronous(command, environmentVars, timeout);
+            return synchronous.execute();
+        } else {
+            throw new IllegalArgumentException("shell command cannot be empty");
+        }
+    }
+
+    @Override
+    public String execute(String[] cmd) {
+        return execute(null, cmd);
+    }
+
     public boolean isCommandRunning(FFtask task) {
         return task != null && !task.isProcessCompleted();
     }

--- a/sample/src/main/java/nl/bravobit/ffmpeg/example/ExampleActivity.java
+++ b/sample/src/main/java/nl/bravobit/ffmpeg/example/ExampleActivity.java
@@ -24,6 +24,7 @@ public class ExampleActivity extends AppCompatActivity {
             // ffmpeg is supported
             versionFFmpeg();
             //ffmpegTestTaskQuit();
+            synchronousVersionFFmpeg();
         } else {
             // ffmpeg is not supported
             Timber.e("ffmpeg not supported!");
@@ -32,6 +33,7 @@ public class ExampleActivity extends AppCompatActivity {
         if (FFprobe.getInstance(this).isSupported()) {
             // ffprobe is supported
             versionFFprobe();
+            synchronousVersionFFprobe();
         } else {
             // ffprobe is not supported
             Timber.e("ffprobe not supported!");
@@ -67,6 +69,16 @@ public class ExampleActivity extends AppCompatActivity {
                 Timber.d(message);
             }
         });
+    }
+
+    private void synchronousVersionFFmpeg() {
+        Timber.d("version ffmpeg synchronous");
+        Timber.d(FFmpeg.getInstance(this).execute(new String[]{"-version"}));
+    }
+
+    private void synchronousVersionFFprobe() {
+        Timber.d("version ffprobe synchronous");
+        Timber.d(FFprobe.getInstance(this).execute(new String[]{"-version"}));
     }
 
     private void ffmpegTestTaskQuit() {


### PR DESCRIPTION
This pull request adds the `FFcommandExecuteSynchronous` class and `execute()` methods needed to execute FFmpeg/FFprobe synchronously as requested in issue #27.

For example, rather than the asynchronous way of executing FFmpeg:
```
FFmpeg ffmpeg = FFmpeg.getInstance(context);
ffmpeg.execute(cmd, new ExecuteBinaryResponseHandler() {

    @Override
    public void onStart() {}

    @Override
    public void onProgress(String message) {}

    @Override
    public void onFailure(String message) {}

    @Override
    public void onSuccess(String message) {}

    @Override
    public void onFinish() {}

});
```

You can now run it synchronously with:
```
FFmpeg ffmpeg = FFmpeg.getInstance(context);
String result = ffmpeg.execute(cmd);
//Result is all the output of the ffmpeg command.
```

It is identical for FFprobe.

Most of the code is pulled from the already-existing asynchronous execution code, I just pulled it out of an `AsyncTask`.

I hope to continue to contribute to this excellent library, and I am willing to make requested changes to this pull request.