### PR TITLE
Append line separator '\n' to output message because original ffmpeg …

### DIFF
--- a/android-ffmpeg/src/main/java/nl/bravobit/ffmpeg/Util.java
+++ b/android-ffmpeg/src/main/java/nl/bravobit/ffmpeg/Util.java
@@ -21,7 +21,7 @@ class Util {
             String str;
             StringBuilder sb = new StringBuilder();
             while ((str = r.readLine()) != null) {
-                sb.append(str);
+                sb.append(str).append('\n');
             }
             return sb.toString();
         } catch (IOException e) {


### PR DESCRIPTION
So i can parse audio/video encoders/decoders from 'ffmpeg -formats' command's output by split line with '\n'.