### PR TITLE
Add section in README to stop or quit the process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ ffmpeg.execute(cmd, new ExecuteBinaryResponseHandler() {
 });
 ```
 
+### Stop (or Quit) the FFmpeg process
+If you want to stop the running FFmpeg process, simply call `.sendQuitSignal()` on the `FFtask` that is running:
+
+```java
+FFmpeg ffmpeg = FFmpeg.getInstance(context);
+FFtask ffTask = ffmpeg.execute( ... )
+
+ffTask.sendQuitSignal();
+```
+
 ### Check if FFprobe is supported
 To check whether FFprobe is available on your device you can use the following method.
 ```java


### PR DESCRIPTION
I had to go hunting for this and found it [here](https://github.com/bravobit/FFmpeg-Android/issues/4) and [here](https://github.com/bravobit/FFmpeg-Android/wiki/Send-'Q'-signal-to-FFmpeg-FFprobe). This is a fairly common use case, especially for people streaming from an RTSP or similar, so let's put it in the README and save future people time, energy and frustration.